### PR TITLE
Preserve url

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ services:
 - `302` for Found
 - `303` for See Other
 - `307` for Temporary Redirect
+
+`PRESERVE_URL` can be set to `true` to enable URLs to be preserve. When set to false, requests will redirect to the location, so `https://example.com/posts/24` will redirect to `https://www.example.com/`. When set to true, it will redirect to `https://www.example.com/posts/24` etc.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redirect",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Redirection lightweight companion container for the nginx-proxy.",
   "main": "server.js",
   "author": "Adam K Dean <adamkdean@googlemail.com?",

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const port = process.env.HTTP_PORT || 80
 const location = process.env.REDIRECT_LOCATION || ''
 const statusCode = parseInt(process.env.REDIRECT_STATUS_CODE) || 307
 
-app.get('*', (req, res) => res.redirect(statusCode, location))
+app.get('*', (req, res) => res.redirect(statusCode, location + req.url))
 app.listen(port, () => {
   console.log(`adamkdean/redirect listening on port ${port}`)
   console.log(`redirecting requests to ${location} with statusCode ${statusCode}`)

--- a/server.js
+++ b/server.js
@@ -12,10 +12,14 @@
 const express = require('express')
 const app = express()
 const port = process.env.HTTP_PORT || 80
-const location = process.env.REDIRECT_LOCATION || ''
 const statusCode = parseInt(process.env.REDIRECT_STATUS_CODE) || 307
+const preserveUrl = process.env.PRESERVE_URL || false
 
-app.get('*', (req, res) => res.redirect(statusCode, location + req.url))
+// Ensure we strip any trailing slashes from REDIRECT_LOCATION
+let location = process.env.REDIRECT_LOCATION || ''
+if (location.endsWith('/')) location = location.substr(0, location.length - 1)
+
+app.get('*', (req, res) => res.redirect(statusCode, preserveUrl ? location + req.url : location))
 app.listen(port, () => {
   console.log(`adamkdean/redirect listening on port ${port}`)
   console.log(`redirecting requests to ${location} with statusCode ${statusCode}`)


### PR DESCRIPTION
Takes #2 and adds in the use of an environment variable `PRESERVE_URL` so that URLs can be preserved without breaking changes being introduced.