### PR TITLE
Disable the x-powered-by header from Express

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,6 +28,9 @@ async function runMultiHost(hosts) {
   const app = express()
   const port = process.env.HTTP_PORT || 80
   const index = {}
+  
+  // Disable x-powered-by header
+  app.disable('x-powered-by')
 
   hosts.forEach(host => {
     if (!host.source || !host.destination) {
@@ -77,6 +80,9 @@ async function runSingleHost() {
   const port = process.env.HTTP_PORT || 80
   const statusCode = parseInt(process.env.REDIRECT_STATUS_CODE) || 307
   const preserveUrl = process.env.PRESERVE_URL || false
+
+  // Disable x-powered-by header
+  app.disable('x-powered-by')
 
   let location = process.env.REDIRECT_LOCATION || ''
   if (!location) {


### PR DESCRIPTION
This removes the unneeded header from the redirect request.


➜  ~ curl -I -L http://site.com
HTTP/1.1 301 Moved Permanently
Server: nginx/1.20.2
Date: Fri, 10 Dec 2021 15:15:07 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 53
Connection: keep-alive
~~X-Powered-By: Express~~
Location: https://targetsite.com/
Vary: Accept