### PR TITLE
Added req.url to host constant

### DIFF
--- a/server.js
+++ b/server.js
@@ -50,7 +50,7 @@ async function runMultiHost(hosts) {
   })
 
   app.get('*', (req, res, next) => {
-    const host = req.headers.host
+    const host = req.headers.host + req.url
 
     // Handle the host if found
     if (index[host]) {


### PR DESCRIPTION
Matching tries to use the req.headers.host, which results in an error if you use a slug after the source url. By adding the slug to the host contant it is possible to redirect from a source with slug to a given url

Example
```json
{
      "source": "localhost/test",
      "destination": "https://lorem.ipsum",
      "statusCode": 301
}
```